### PR TITLE
Fixed issue with `warn` messages not being processed by syslog.

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,8 +66,13 @@ module.exports = function(moduleConfig) {
 		log = sysLogger.log;
 
 		sysLogger.log = function(level, msg, meta, callback){
-			var formattedMsg = util.getSyslogMsg(level, msg, meta);
-			log.call(sysLogger, level, formattedMsg, meta, callback);
+			log.call(
+				sysLogger,
+				util.getSyslogLevel(level),
+				util.getSyslogMsg(msg),
+				meta,
+				callback
+			);
 		}
 	}
 

--- a/util.js
+++ b/util.js
@@ -9,10 +9,7 @@ function getTimeStamp() {
   return date.toISOString();
 }
 
-function getSyslogMsg(level, msg, meta){
-  if (level === 'warn') {
-    level = 'warning';
-  }
+function getSyslogMsg(msg){
 
   var app_ver = process.versions.app || "none";
   var formattedMsg = util.format(
@@ -28,8 +25,17 @@ function getSyslogMsg(level, msg, meta){
   return formattedMsg;
 }
 
+function getSyslogLevel(level){
+  if (level === 'warn') {
+    level = 'warning';
+  }
+
+  return level;
+}
+
 module.exports = {
   formatArgs: formatArgs,
   getTimeStamp: getTimeStamp,
-  getSyslogMsg: getSyslogMsg
+  getSyslogMsg: getSyslogMsg,
+  getSyslogLevel: getSyslogLevel
 };


### PR DESCRIPTION
The current `getSyslogMsg()` function modifies the `level` argument's value from `warn` to `warning` to match what the syslogger is expecting, but because of the pass-by-value semantics of JS the modification isn't actually changing the value that's ultimately passed to the syslogger. Therefore, `warn` log messages aren't being processed by the syslogger.

This change creates a new function, `getSyslogLevel()`, that does the same modification of the level, but returns the modified value so the correct level is passed to the syslogger.

This also removes the `meta` argument from the `getSyslogMsg()` function, since it's not being used there anyways.